### PR TITLE
kalman: rationalise implementation a little

### DIFF
--- a/doc/kalman.rst
+++ b/doc/kalman.rst
@@ -278,9 +278,8 @@ noisy measurements.
 
     # For each time step
     for k, z in enumerate(measurements):
-        # There's no point predicting for the first time step
-        if k != 0:
-            kf.predict()
+        # Predict state for this timestep
+        kf.predict()
 
         # Update filter with measurement
         kf.update(z)

--- a/example/kalman_filtering.py
+++ b/example/kalman_filtering.py
@@ -100,9 +100,8 @@ kf = KalmanFilter(
 
 # For each time step
 for k, z in enumerate(measurements):
-    # There's no point predicting for the first time step
-    if k != 0:
-        kf.predict()
+    # Predict state for this time step
+    kf.predict()
 
     # Update filter with measurement
     kf.update(z)

--- a/test/test_kalman.py
+++ b/test/test_kalman.py
@@ -91,9 +91,8 @@ def create_filter(true_states, measurements):
 
     # For each time step
     for k, z in enumerate(measurements):
-        # There's no point predicting for the first time step
-        if k != 0:
-            kf.predict()
+        # Predict
+        kf.predict()
 
         # Update filter with measurement
         kf.update(z)


### PR DESCRIPTION
It was unusual that the idiom for calling the Kalman filter was predict() then
update() for all time steps _except_ the first one. Change the implementation to
make this work-around unnecessary.
