### PR TITLE
travis: pre-install numpy and matplotlib and make tox use sitepackages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 install:
     - pip install --upgrade pip
-    - pip install tox coveralls
+    - pip install tox coveralls numpy matplotlib
 matrix:
     include:
     - python: "3.4"
@@ -22,5 +22,5 @@ matrix:
     - python: "2.7"
       env:
         - TOX_ENV=examples-py27
-script: tox -e $TOX_ENV
+script: tox --sitepackages -e $TOX_ENV
 after_success: coveralls


### PR DESCRIPTION
It takes a long time for tox to install dependencies at the moment and so one my
not get output for >10 mins. Travis then kills the job. Pre-install numpy and
matplotlib via pip to try and avoid this.
